### PR TITLE
Fixed an issue where if we had a hasMany inside a hasMany and both of…

### DIFF
--- a/src/types/multiModel.js
+++ b/src/types/multiModel.js
@@ -72,6 +72,10 @@ class MultiModel extends BaseType {
     }
 
     all (): Array<Object> {
+        if (!this.options.batchRequest && !this.map.all().length) {
+            return [];
+        }
+
         if (!this.requestCache.get(this.Model, this._parent, this.options.defaultQuery)) {
             this.requestMany(this.options.defaultQuery);
         }
@@ -159,6 +163,7 @@ class MultiModel extends BaseType {
             this.map.all().forEach((id) => {
                 this.requestOne(id, options);
             });
+
             return;
         }
 

--- a/src/util/requestCache.js
+++ b/src/util/requestCache.js
@@ -23,6 +23,7 @@ class RequestCache {
     }
 
     get (Model: Function, context: Object, query: Object = {}) : ?Array<Object> {
+
         if (!Model || !context) {
             throw new TypeError('RequestCache.get(): Model and context are not optional');
         }


### PR DESCRIPTION
… them were not batch requested the child hasMany got the requests cached before the ids to map with became available
